### PR TITLE
Remove isWriteOperation on container delete

### DIFF
--- a/sdk/data/azcosmos/cosmos_container.go
+++ b/sdk/data/azcosmos/cosmos_container.go
@@ -138,9 +138,8 @@ func (c *ContainerClient) Delete(
 	}
 
 	operationContext := pipelineRequestOptions{
-		resourceType:     resourceTypeCollection,
-		resourceAddress:  c.link,
-		isWriteOperation: true,
+		resourceType:    resourceTypeCollection,
+		resourceAddress: c.link,
 	}
 
 	path, err := generatePathForNameBased(resourceTypeCollection, c.link, false)


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

For some reasons I'm getting back 500 errors when I attempt to delete a cosmos container. If I remove `isWriteOperation: true,` the Delete is successful.

I'm not sure if this is a server issue, or a client issue, but my hopes is that this PR can either spark the investigation or lead to a fix.

Interestingly I see that `(Database).Delete` also uses `isWriteOperation: true,` and that operation is successful for me (with with and without the option)


- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
